### PR TITLE
fix: Prevent leading slash in download path when saving to root

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -193,7 +193,7 @@ async function handleDownloadImages(images, context) {
                 safeFilename = `image_${Date.now()}_${downloadedCount}.png`;
             }
 
-            const fullFilename = `${downloadPath}/${safeFilename}`;
+            const fullFilename = downloadPath ? `${downloadPath}/${safeFilename}` : safeFilename;
             debugLog('[AI Meta Viewer] Registering path & Requesting download:', fullFilename);
 
             // イベントリスナー用にキューへパスを登録


### PR DESCRIPTION
- Fix an edge case where an empty downloadPath would result in a filename starting with a slash (e.g., /image.png), which could cause download failures.
- Path construction now correctly handles cases with no main or subfolders.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes handling of empty downloadPath so saving to root no longer produces a leading slash in the filename. Root saves now use image.png instead of /image.png, preventing download failures.

<sup>Written for commit 50541413362345ff1ed48bfdf889e53e8e26dec4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

