### PR TITLE
feat: メタデータの表示領域をテキストエディタ形式に変更

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -172,5 +172,26 @@
   },
   "msgAllDataClearFailed": {
     "message": "Failed to clear all data: "
+  },
+  "sectionWindowDisplay": {
+    "message": "Window Display"
+  },
+  "labelModalWidth": {
+    "message": "Width (px)"
+  },
+  "labelModalHeight": {
+    "message": "Height (px)"
+  },
+  "btnResetWindow": {
+    "message": "Reset Size & Position"
+  },
+  "sectionMetadataInteraction": {
+    "message": "Metadata Interaction"
+  },
+  "labelEnableMetadataEditing": {
+    "message": "Enable Metadata Editing"
+  },
+  "descEnableMetadataEditing": {
+    "message": "Allow editing metadata text directly in the viewer modal (Experimental)"
   }
 }

--- a/extension/_locales/ja/messages.json
+++ b/extension/_locales/ja/messages.json
@@ -166,5 +166,26 @@
     },
     "msgAllDataClearFailed": {
         "message": "全データのクリアに失敗しました: "
+    },
+    "sectionWindowDisplay": {
+        "message": "ウィンドウ表示"
+    },
+    "labelModalWidth": {
+        "message": "幅 (px)"
+    },
+    "labelModalHeight": {
+        "message": "高さ (px)"
+    },
+    "btnResetWindow": {
+        "message": "サイズ・位置をリセット"
+    },
+    "sectionMetadataInteraction": {
+        "message": "メタデータ操作"
+    },
+    "labelEnableMetadataEditing": {
+        "message": "メタデータ編集を有効化"
+    },
+    "descEnableMetadataEditing": {
+        "message": "ビューアモーダルでメタデータテキストを直接編集できるようにします（実験的）"
     }
 }

--- a/extension/background.js
+++ b/extension/background.js
@@ -487,7 +487,7 @@ const DEFAULT_SETTINGS = {
     downloaderFolderMode: 'id_pageTitle', // 'id_pageTitle', 'pageTitle', 'domain', 'none'
     downloaderBaseFolder: 'AI_Meta_Viewer',
     downloaderUseRoot: false,
-    version: '1.5.2',
+    version: '1.5.3',
     // 共有設定の追加
     modalWidth: 800,
     modalHeight: 600,
@@ -675,7 +675,7 @@ async function handleWriteMetadataAndDownload(imageUrl, metadataObj) {
 
         const modifiedBytes = await rewriteImageMetadata(buffer, finalMetadataText);
         const format = detectImageFormat(buffer);
-        const mimeType = format === 'png' ? 'image/png' : (format === 'webp' ? 'image/webp' : 'image/jpeg');
+        const mimeType = format === 'png' ? 'image/png' : format === 'webp' ? 'image/webp' : format === 'avif' ? 'image/avif' : 'image/jpeg';
         const blob = new Blob([modifiedBytes], { type: mimeType });
 
         // Service Worker 環境での Data URL 化
@@ -699,9 +699,10 @@ async function handleWriteMetadataAndDownload(imageUrl, metadataObj) {
         }
 
         // 元のベース名と拡張子を分離
-        let baseName = filename.substring(0, filename.lastIndexOf('.')) || filename;
+        const dotIndex = filename.lastIndexOf('.');
+        let baseName = dotIndex !== -1 ? filename.substring(0, dotIndex) : filename;
         // 拡張子を小文字に正規化
-        const extension = (filename.substring(filename.lastIndexOf('.')) || `.${format || 'png'}`).toLowerCase();
+        const extension = (dotIndex !== -1 ? filename.substring(dotIndex) : `.${format || 'png'}`).toLowerCase();
 
         // ファイル名として不適切な文字を置換 (Windows/OSの制限)
         baseName = baseName.replace(/[\\/:*?"<>|]/g, '_');

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,4 +1,9 @@
 // background.js - Universal Background Script (Chrome & Firefox)
+try {
+    importScripts('pako.js', 'jszip.min.js', 'parser.js');
+} catch (e) {
+    console.error('[AI Meta Viewer] Failed to import scripts in Service Worker:', e);
+}
 
 // ブラウザAPI統一（Chrome/Firefox両対応）
 const browserAPI = (() => {
@@ -482,7 +487,15 @@ const DEFAULT_SETTINGS = {
     downloaderFolderMode: 'id_pageTitle', // 'id_pageTitle', 'pageTitle', 'domain', 'none'
     downloaderBaseFolder: 'AI_Meta_Viewer',
     downloaderUseRoot: false,
-    version: '1.4.0'
+    version: '1.5.2',
+    // 共有設定の追加
+    modalWidth: 800,
+    modalHeight: 600,
+    modalX: 'center',
+    modalY: 'center',
+    enableMetadataEditing: false,
+    advancedModeEnabled: false,
+    enableExperimentalWriting: false
 };
 
 // 現在の設定（起動時に読み込み）
@@ -621,7 +634,101 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             });
         return true;
     }
+
+    if (request.action === 'writeMetadataAndDownload') {
+        handleWriteMetadataAndDownload(request.imageUrl, request.metadata)
+            .then(sendResponse)
+            .catch(error => {
+                console.error('Write metadata error:', error);
+                sendResponse({ success: false, error: error.message });
+            });
+        return true;
+    }
 });
+
+/**
+ * メタデータを書き換えてダウンロードを実行
+ * (隠し機能)
+ */
+async function handleWriteMetadataAndDownload(imageUrl, metadataObj) {
+    debugLog('[AI Meta Viewer] Starting metadata rewrite/download for:', imageUrl);
+    try {
+        const response = await fetch(imageUrl);
+        if (!response.ok) throw new Error(`Failed to fetch image: ${response.status}`);
+
+        const buffer = await response.arrayBuffer();
+
+        // メタデータの統合 (Positive, Negative, Other を A1111 形式に再構成)
+        let finalMetadataText = '';
+        if (typeof metadataObj === 'string') {
+            finalMetadataText = metadataObj;
+        } else {
+            const { positive, negative, other } = metadataObj;
+            finalMetadataText = (positive || '').trim();
+            if (negative && negative.trim()) {
+                finalMetadataText += `\nNegative prompt: ${(negative || '').trim()}`;
+            }
+            if (other && other.trim()) {
+                finalMetadataText += `\n${(other || '').trim()}`;
+            }
+        }
+
+        const modifiedBytes = await rewriteImageMetadata(buffer, finalMetadataText);
+        const format = detectImageFormat(buffer);
+        const mimeType = format === 'png' ? 'image/png' : (format === 'webp' ? 'image/webp' : 'image/jpeg');
+        const blob = new Blob([modifiedBytes], { type: mimeType });
+
+        // Service Worker 環境での Data URL 化
+        const dataUrl = await new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onloadend = () => resolve(reader.result);
+            reader.onerror = reject;
+            reader.readAsDataURL(blob);
+        });
+
+        // 元のファイル名を維持
+        const urlObj = new URL(imageUrl);
+        const pathSegments = urlObj.pathname.split('/');
+        let filename = pathSegments.pop() || 'image';
+
+        // デコードとクエリパラメータ除去
+        try {
+            filename = decodeURIComponent(filename.split('?')[0]);
+        } catch (e) {
+            filename = filename.split('?')[0];
+        }
+
+        // 元のベース名と拡張子を分離
+        let baseName = filename.substring(0, filename.lastIndexOf('.')) || filename;
+        // 拡張子を小文字に正規化
+        const extension = (filename.substring(filename.lastIndexOf('.')) || `.${format || 'png'}`).toLowerCase();
+
+        // ファイル名として不適切な文字を置換 (Windows/OSの制限)
+        baseName = baseName.replace(/[\\/:*?"<>|]/g, '_');
+
+        // ファイル名長制限
+        const MAX_BASENAME_LENGTH = 80;
+        if (baseName.length > MAX_BASENAME_LENGTH) {
+            baseName = baseName.substring(0, MAX_BASENAME_LENGTH);
+        }
+
+        // フォルダ名をプレフィックスとして付与し、ブラウザに「意図的な保存」であることを伝える
+        // これにより Data URL 使用時でも指定名が優先されやすくなる
+        const finalPath = `AI_Meta_Viewer/${baseName}_edited${extension}`;
+        debugLog('[AI Meta Viewer] Final download path:', finalPath);
+        debugLog('[AI Meta Viewer] Data URL length:', dataUrl.length);
+
+        await chrome.downloads.download({
+            url: dataUrl,
+            filename: finalPath,
+            saveAs: true
+        });
+
+        return { success: true };
+    } catch (e) {
+        throw e;
+    }
+}
 
 /**
  * メディアのファイルサイズを取得(HEADリクエスト)

--- a/extension/badge_controller.js
+++ b/extension/badge_controller.js
@@ -175,7 +175,7 @@ function addBadgeToImage(img, metadata, originalUrl) {
 
     // ui.jsのupdateBadgeでツールチップなどを設定
     updateBadge(badge, metadata);
-    badge.style.zIndex = '2147483647'; // 最前面に表示
+    badge.style.zIndex = '2147483640'; // モーダル(2147483647)より手前にならないよう、かつ十分に高く設定
 
     // バッジにメタデータとオリジナルURLを保存
     badge._metadata = metadata;
@@ -205,7 +205,7 @@ function addBadgeToImage(img, metadata, originalUrl) {
 
         const currentMetadata = badge._metadata;
         if (currentMetadata && document.body) {
-            const modal = createModal(currentMetadata); // ui.jsの関数
+            const modal = createModal(currentMetadata, badge._originalUrl); // ui.jsの関数
             document.body.appendChild(modal);
         }
     });
@@ -488,7 +488,7 @@ function addBadgeToElement(el, metadata, originalUrl) {
         e.stopPropagation();
         const currentMetadata = badge._metadata;
         if (currentMetadata && document.body) {
-            const modal = createModal(currentMetadata);
+            const modal = createModal(currentMetadata, badge._originalUrl);
             document.body.appendChild(modal);
         }
     });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "permissions": [
         "activeTab",
         "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "1.5.1.1",
+    "version": "1.5.2",
     "permissions": [
         "activeTab",
         "storage",

--- a/extension/options.html
+++ b/extension/options.html
@@ -466,15 +466,15 @@
 
             <!-- ウィンドウ表示設定 -->
             <div class="section">
-                <h2 class="section-title">Window Display</h2>
+                <h2 class="section-title" data-i18n="sectionWindowDisplay">Window Display</h2>
                 <div class="setting-item">
                     <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
                         <div class="input-group">
-                            <label for="modalWidth">Width (px)</label>
+                            <label for="modalWidth" data-i18n="labelModalWidth">Width (px)</label>
                             <input type="number" id="modalWidth" min="300" max="2000">
                         </div>
                         <div class="input-group">
-                            <label for="modalHeight">Height (px)</label>
+                            <label for="modalHeight" data-i18n="labelModalHeight">Height (px)</label>
                             <input type="number" id="modalHeight" min="200" max="2000">
                         </div>
                     </div>
@@ -482,20 +482,23 @@
                 <div class="setting-item">
                     <p class="input-helper">Position (Current: <span id="currentPos">Auto</span>)</p>
                     <button class="btn btn-secondary" id="resetWindowBtn"
-                        style="margin-top: 8px; width: auto; font-size: 12px; padding: 6px 12px;">Reset Size &
+                        style="margin-top: 8px; width: auto; font-size: 12px; padding: 6px 12px;"
+                        data-i18n="btnResetWindow">Reset Size &
                         Position</button>
                 </div>
             </div>
 
             <!-- 編集設定 -->
             <div class="section">
-                <h2 class="section-title">Metadata Interaction</h2>
+                <h2 class="section-title" data-i18n="sectionMetadataInteraction">Metadata Interaction</h2>
                 <div class="setting-item">
                     <label class="setting-label">
                         <input type="checkbox" id="enableMetadataEditing">
                         <div class="setting-label-text">
-                            <div class="setting-label-title">Enable Metadata Editing</div>
-                            <div class="setting-label-desc">Allow editing metadata text directly in the viewer modal
+                            <div class="setting-label-title" data-i18n="labelEnableMetadataEditing">Enable Metadata
+                                Editing</div>
+                            <div class="setting-label-desc" data-i18n="descEnableMetadataEditing">Allow editing metadata
+                                text directly in the viewer modal
                                 (Experimental)</div>
                         </div>
                     </label>

--- a/extension/options.html
+++ b/extension/options.html
@@ -464,6 +464,62 @@
                 </div>
             </div>
 
+            <!-- ウィンドウ表示設定 -->
+            <div class="section">
+                <h2 class="section-title">Window Display</h2>
+                <div class="setting-item">
+                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
+                        <div class="input-group">
+                            <label for="modalWidth">Width (px)</label>
+                            <input type="number" id="modalWidth" min="300" max="2000">
+                        </div>
+                        <div class="input-group">
+                            <label for="modalHeight">Height (px)</label>
+                            <input type="number" id="modalHeight" min="200" max="2000">
+                        </div>
+                    </div>
+                </div>
+                <div class="setting-item">
+                    <p class="input-helper">Position (Current: <span id="currentPos">Auto</span>)</p>
+                    <button class="btn btn-secondary" id="resetWindowBtn"
+                        style="margin-top: 8px; width: auto; font-size: 12px; padding: 6px 12px;">Reset Size &
+                        Position</button>
+                </div>
+            </div>
+
+            <!-- 編集設定 -->
+            <div class="section">
+                <h2 class="section-title">Metadata Interaction</h2>
+                <div class="setting-item">
+                    <label class="setting-label">
+                        <input type="checkbox" id="enableMetadataEditing">
+                        <div class="setting-label-text">
+                            <div class="setting-label-title">Enable Metadata Editing</div>
+                            <div class="setting-label-desc">Allow editing metadata text directly in the viewer modal
+                                (Experimental)</div>
+                        </div>
+                    </label>
+                </div>
+            </div>
+
+            <!-- 高度な設定 (Hidden) -->
+            <div id="advancedSection" class="section"
+                style="display: none; border: 2px dashed #f44336; padding: 20px; border-radius: 12px; background: #fff5f5; margin-bottom: 20px;">
+                <h2 class="section-title" style="color: #d32f2f; margin-bottom: 12px;">🔥 Advanced Experimental Features
+                </h2>
+                <div class="setting-item">
+                    <label class="setting-label" style="background: transparent;">
+                        <input type="checkbox" id="enableExperimentalWriting">
+                        <div class="setting-label-text">
+                            <div class="setting-label-title" style="color: #333;">Enable metadata rewrite and download
+                            </div>
+                            <div class="setting-label-desc" style="color: #666;">Adds a button to download a new image
+                                with modified metadata embedded (PNG only)</div>
+                        </div>
+                    </label>
+                </div>
+            </div>
+
             <!-- 保存・リセットボタン -->
             <div class="button-group">
                 <button class="btn btn-primary" id="saveBtn" data-i18n="btnSave">💾 Save</button>
@@ -471,6 +527,10 @@
             </div>
 
             <div class="status-message" id="statusMessage"></div>
+
+            <div style="text-align: center; margin-top: 20px; color: #999; font-size: 12px;">
+                AI Meta Viewer <span id="versionDisplay" style="user-select: none;">v1.x.x</span>
+            </div>
         </div>
     </div>
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -14,7 +14,14 @@ const DEFAULT_SETTINGS = {
     downloaderFolderMode: 'id_pageTitle',
     downloaderBaseFolder: 'AI_Meta_Viewer',
     downloaderUseRoot: false,
-    version: '1.5.1.1'
+    modalWidth: 600,
+    modalHeight: 500,
+    modalX: 'center',
+    modalY: 'center',
+    enableMetadataEditing: false,
+    enableExperimentalWriting: false,
+    advancedModeEnabled: false,
+    version: '1.5.3'
 };
 
 // DOM Elements
@@ -36,6 +43,16 @@ const downloaderFolderModeSelect = document.getElementById('downloaderFolderMode
 const downloaderBaseFolderInput = document.getElementById('downloaderBaseFolder');
 const downloaderUseRootCheckbox = document.getElementById('downloaderUseRoot');
 const baseFolderContainer = document.getElementById('baseFolderContainer');
+
+// Window & Interaction Elements
+const modalWidthInput = document.getElementById('modalWidth');
+const modalHeightInput = document.getElementById('modalHeight');
+const currentPosSpan = document.getElementById('currentPos');
+const resetWindowBtn = document.getElementById('resetWindowBtn');
+const enableMetadataEditingCheckbox = document.getElementById('enableMetadataEditing');
+const enableExperimentalWritingCheckbox = document.getElementById('enableExperimentalWriting');
+const advancedSection = document.getElementById('advancedSection');
+const versionDisplay = document.getElementById('versionDisplay');
 
 // Data Statistics Elements
 const cacheItemCountSpan = document.getElementById('cacheItemCount');
@@ -202,6 +219,25 @@ async function loadSettings() {
         updateBaseFolderVisibility();
     }
 
+    // Window & Interaction
+    if (modalWidthInput) modalWidthInput.value = settings.modalWidth;
+    if (modalHeightInput) modalHeightInput.value = settings.modalHeight;
+    if (currentPosSpan) {
+        if (settings.modalX === 'center') {
+            currentPosSpan.textContent = 'Centered';
+        } else {
+            currentPosSpan.textContent = `X:${Math.round(settings.modalX)}, Y:${Math.round(settings.modalY)}`;
+        }
+    }
+    if (enableMetadataEditingCheckbox) enableMetadataEditingCheckbox.checked = settings.enableMetadataEditing;
+    if (enableExperimentalWritingCheckbox) enableExperimentalWritingCheckbox.checked = settings.enableExperimentalWriting;
+
+    // Advanced Mode
+    if (advancedSection) {
+        advancedSection.style.display = settings.advancedModeEnabled ? 'block' : 'none';
+    }
+    if (versionDisplay) versionDisplay.textContent = 'v' + settings.version;
+
     // データ統計を表示
     await OptionsPageEnhancer.displayDataStatistics();
 }
@@ -235,7 +271,12 @@ async function saveSettings() {
         ignoredSoftware: ignoredSoftware,
         downloaderFolderMode: downloaderFolderModeSelect ? downloaderFolderModeSelect.value : 'pageTitle',
         downloaderBaseFolder: downloaderBaseFolderInput ? downloaderBaseFolderInput.value.trim() : 'AI_Meta_Viewer',
-        downloaderUseRoot: downloaderUseRootCheckbox ? downloaderUseRootCheckbox.checked : false
+        downloaderUseRoot: downloaderUseRootCheckbox ? downloaderUseRootCheckbox.checked : false,
+        modalWidth: parseInt(modalWidthInput ? modalWidthInput.value : '600', 10) || 600,
+        modalHeight: parseInt(modalHeightInput ? modalHeightInput.value : '500', 10) || 500,
+        enableMetadataEditing: enableMetadataEditingCheckbox ? enableMetadataEditingCheckbox.checked : false,
+        enableExperimentalWriting: enableExperimentalWritingCheckbox ? enableExperimentalWritingCheckbox.checked : false,
+        advancedModeEnabled: advancedSection ? (advancedSection.style.display !== 'none') : false
     };
 
     // Validation
@@ -353,5 +394,39 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (downloaderUseRootCheckbox) {
         downloaderUseRootCheckbox.addEventListener('change', updateBaseFolderVisibility);
+    }
+
+    // Reset Window Click
+    if (resetWindowBtn) {
+        resetWindowBtn.addEventListener('click', () => {
+            const updates = {
+                modalWidth: 600,
+                modalHeight: 500,
+                modalX: 'center',
+                modalY: 'center'
+            };
+            chrome.storage.sync.set(updates, () => {
+                if (modalWidthInput) modalWidthInput.value = 600;
+                if (modalHeightInput) modalHeightInput.value = 500;
+                if (currentPosSpan) currentPosSpan.textContent = 'Centered';
+                showStatus('Window reset to defaults', 'success');
+            });
+        });
+    }
+
+    // Secret version clicking logic
+    let versionClicks = 0;
+    if (versionDisplay) {
+        versionDisplay.addEventListener('click', () => {
+            versionClicks++;
+            if (versionClicks >= 5) {
+                if (advancedSection) {
+                    advancedSection.style.display = 'block';
+                    showStatus('🔥 Advanced Settings Unlocked!', 'success');
+                    // 保存もしておく
+                    chrome.storage.sync.set({ advancedModeEnabled: true });
+                }
+            }
+        });
     }
 });

--- a/extension/options.js
+++ b/extension/options.js
@@ -400,14 +400,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (resetWindowBtn) {
         resetWindowBtn.addEventListener('click', () => {
             const updates = {
-                modalWidth: 600,
-                modalHeight: 500,
-                modalX: 'center',
-                modalY: 'center'
+                modalWidth: DEFAULT_SETTINGS.modalWidth,
+                modalHeight: DEFAULT_SETTINGS.modalHeight,
+                modalX: DEFAULT_SETTINGS.modalX,
+                modalY: DEFAULT_SETTINGS.modalY
             };
             chrome.storage.sync.set(updates, () => {
-                if (modalWidthInput) modalWidthInput.value = 600;
-                if (modalHeightInput) modalHeightInput.value = 500;
+                if (modalWidthInput) modalWidthInput.value = DEFAULT_SETTINGS.modalWidth;
+                if (modalHeightInput) modalHeightInput.value = DEFAULT_SETTINGS.modalHeight;
                 if (currentPosSpan) currentPosSpan.textContent = 'Centered';
                 showStatus('Window reset to defaults', 'success');
             });

--- a/extension/parser.js
+++ b/extension/parser.js
@@ -1009,8 +1009,9 @@ async function rewriteImageMetadata(buffer, text) {
     case 'webp':
       return writeWebPMetadata(buffer, text);
     case 'jpeg':
+      return writeJpegMetadata(buffer, text);
     case 'avif':
-      return writeJpegMetadata(buffer, text); // AVIFもJPEG同様APP1/Exifを使用
+      throw new Error('AVIF metadata rewriting is not supported. AVIF uses ISOBMFF container format which requires a different approach.');
     default:
       throw new Error(`Unsupported format for rewriting: ${format}`);
   }
@@ -1077,6 +1078,13 @@ function writeWebPMetadata(buffer, text) {
 function writeJpegMetadata(buffer, text) {
   const view = new Uint8Array(buffer);
   const textBytes = new TextEncoder().encode(text);
+
+  // COM segment length field is 2 bytes (max 65535, including the 2-byte length field itself)
+  // So max text payload is 65533 bytes
+  const MAX_COM_PAYLOAD = 65533;
+  if (textBytes.length > MAX_COM_PAYLOAD) {
+    throw new Error(`Metadata text too large for JPEG COM segment (${textBytes.length} bytes > ${MAX_COM_PAYLOAD} bytes max). Consider using a shorter prompt.`);
+  }
 
   // COM marker: FF FE, Length: 2 + textBytes.length
   const comSegment = new Uint8Array(2 + 2 + textBytes.length);

--- a/extension/parser.js
+++ b/extension/parser.js
@@ -134,9 +134,23 @@ function parsePngTextChunk(type, chunkData, metadata) {
     if (transEnd === -1) return;
     pos = transEnd + 1;
 
-    if (compressionFlag === 0) { // 非圧縮のみ対応
+    if (compressionFlag === 0) {
       const text = new TextDecoder('utf-8').decode(chunkData.slice(pos));
       metadata[keyword] = text;
+    } else if (compressionFlag === 1) {
+      // 圧縮された iTXt チャンクのデコード (HANDOVER 指示に基づく)
+      try {
+        if (typeof pako !== 'undefined') {
+          const compressedData = chunkData.slice(pos);
+          const inflated = pako.inflate(compressedData);
+          const text = new TextDecoder('utf-8').decode(inflated);
+          metadata[keyword] = text;
+        } else {
+          console.warn('[AI Meta Viewer] pako.js not loaded, cannot decompress iTXt chunk');
+        }
+      } catch (err) {
+        console.error('[AI Meta Viewer] Failed to decompress iTXt chunk:', err);
+      }
     }
   }
 }
@@ -858,4 +872,235 @@ function binaryToText(binaryStr) {
   } catch {
     return '';
   }
+}
+
+/**
+ * PNG画像のバイナリデータを取得し、メタデータを書き換えた新しいデータを返す
+ * (既存の tEXt/iTXt チャンクを上書き、または新規挿入)
+ * @param {ArrayBuffer} buffer - 元の画像データ
+ * @param {string} text - 書き込むプロンプトテキスト
+ * @returns {Uint8Array} - 書き換え後の画像データ
+ */
+function writePngMetadata(buffer, text) {
+  const bytes = new Uint8Array(buffer);
+  const chunks = [];
+  let offset = 8; // Skip PNG header
+
+  // ヘッダーをコピー
+  chunks.push(bytes.slice(0, 8));
+
+  let inserted = false;
+
+  while (offset < bytes.length) {
+    const length = new DataView(bytes.buffer, offset, 4).getUint32(0);
+    const type = new TextDecoder('ascii').decode(bytes.slice(offset + 4, offset + 8));
+
+    // 既存の parameters チャンクがあればスキップ（上書きの代わり）
+    if (type === 'tEXt' || type === 'iTXt') {
+      const chunkContent = bytes.slice(offset + 8, offset + 8 + length);
+      let keywordEnd = -1;
+      for (let i = 0; i < chunkContent.length; i++) {
+        if (chunkContent[i] === 0) {
+          keywordEnd = i;
+          break;
+        }
+      }
+
+      if (keywordEnd !== -1) {
+        const keyword = new TextDecoder('ascii').decode(chunkContent.slice(0, keywordEnd));
+        if (keyword === 'parameters') {
+          offset += length + 12;
+          continue;
+        }
+      }
+    }
+
+    const fullChunk = bytes.slice(offset, offset + length + 12);
+    chunks.push(fullChunk);
+
+    // IHDR チャンクの直後に新しい parameters チャンクを挿入する
+    if (type === 'IHDR' && !inserted) {
+      chunks.push(createPngTextChunk('parameters', text));
+      inserted = true;
+    }
+
+    offset += length + 12;
+    if (offset > bytes.length - 4) break; // 安全策
+  }
+
+  // Flatten chunks
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const result = new Uint8Array(totalLength);
+  let pos = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, pos);
+    pos += chunk.length;
+  }
+  return result;
+}
+
+/**
+ * PNG tEXt チャンクを生成
+ */
+function createPngTextChunk(keyword, text) {
+  const encoder = new TextEncoder();
+  const kwBytes = encoder.encode(keyword);
+  const textBytes = encoder.encode(text);
+
+  const length = kwBytes.length + 1 + textBytes.length;
+  const buffer = new ArrayBuffer(length + 12);
+  const view = new DataView(buffer);
+
+  // Length
+  view.setUint32(0, length);
+
+  // Type: tEXt
+  view.setUint8(4, 0x74); // t
+  view.setUint8(5, 0x45); // E
+  view.setUint8(6, 0x58); // X
+  view.setUint8(7, 0x74); // t
+
+  const bytes = new Uint8Array(buffer);
+  // Keyword + Null separator + Text
+  bytes.set(kwBytes, 8);
+  bytes.set([0], 8 + kwBytes.length);
+  bytes.set(textBytes, 9 + kwBytes.length);
+
+  // CRC
+  const crcData = bytes.slice(4, 8 + length);
+  const crc = computeCrc32(crcData);
+  view.setUint32(8 + length, crc);
+
+  return bytes;
+}
+
+// CRC32 implementation
+function computeCrc32(data) {
+  let crc = 0xFFFFFFFF;
+  const globalObj = typeof self !== 'undefined' ? self : window;
+  const table = globalObj._crcTable || (globalObj._crcTable = (() => {
+    const t = new Uint32Array(256);
+    for (let i = 0; i < 256; i++) {
+      let c = i;
+      for (let j = 0; j < 8; j++) {
+        c = ((c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1));
+      }
+      t[i] = c;
+    }
+    return t;
+  })());
+
+  for (let i = 0; i < data.length; i++) {
+    crc = table[(crc ^ data[i]) & 0xFF] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+/**
+ * 画像形式を判別してメタデータを書き換える (統合エントリポイント)
+ */
+async function rewriteImageMetadata(buffer, text) {
+  const format = detectImageFormat(buffer);
+  debugLog(`[AI Meta Viewer] Rewriting metadata for format: ${format}`);
+
+  switch (format) {
+    case 'png':
+      return writePngMetadata(buffer, text);
+    case 'webp':
+      return writeWebPMetadata(buffer, text);
+    case 'jpeg':
+    case 'avif':
+      return writeJpegMetadata(buffer, text); // AVIFもJPEG同様APP1/Exifを使用
+    default:
+      throw new Error(`Unsupported format for rewriting: ${format}`);
+  }
+}
+
+/**
+ * WebPにメタデータ(XMP)を埋め込む
+ * シンプルにVP8Xヘッダを更新し、末尾にXMPチャンクを追加（または上書き）
+ */
+function writeWebPMetadata(buffer, text) {
+  const view = new Uint8Array(buffer);
+  const xmpHeader = '<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:description><rdf:Alt><rdf:li xml:lang="x-default">';
+  const xmpFooter = '</rdf:li></rdf:Alt></dc:description></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="w"?>';
+  const xmpContent = xmpHeader + text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') + xmpFooter;
+  const xmpBytes = new TextEncoder().encode(xmpContent);
+
+  // RIFF(4) + Size(4) + WEBP(4)
+  // 既存の XMP チャンクを探して削除するための簡易実装
+  // 実際にはチャンクをパースして再構築するのが安全だが、
+  // ここでは新しい XMP チャンクを生成して IDAT (または VP8/VP8L) の後に追加
+
+  const chunks = [];
+  let offset = 12;
+  while (offset < view.length - 8) {
+    const type = String.fromCharCode(...view.slice(offset, offset + 4));
+    const size = view[offset + 4] | (view[offset + 5] << 8) | (view[offset + 6] << 16) | (view[offset + 7] << 24);
+    const fullSize = 8 + size + (size % 2);
+
+    if (type !== 'XMP ') { // 既存の XMP はスキップ
+      chunks.push(view.slice(offset, offset + fullSize));
+    }
+    offset += fullSize;
+  }
+
+  // VP8X チャンクが存在しない場合は追加し、フラグを立てる必要があるが、
+  // 多くのAI生成WebPは既にVP8Xを持っているか、末尾追加でも読み取れる場合が多い
+  // ここではシンプルに結合
+  const newSize = 4 + chunks.reduce((acc, c) => acc + c.length, 0) + 8 + xmpBytes.length + (xmpBytes.length % 2);
+  const out = new Uint8Array(8 + newSize);
+
+  out.set([0x52, 0x49, 0x46, 0x46]); // RIFF
+  const outView = new DataView(out.buffer);
+  outView.setUint32(4, newSize, true);
+  out.set([0x57, 0x45, 0x42, 0x50], 8); // WEBP
+
+  let currentPos = 12;
+  for (const c of chunks) {
+    out.set(c, currentPos);
+    currentPos += c.length;
+  }
+
+  // XMP チャンク追加
+  out.set(new TextEncoder().encode('XMP '), currentPos);
+  outView.setUint32(currentPos + 4, xmpBytes.length, true);
+  out.set(xmpBytes, currentPos + 8);
+
+  return out;
+}
+
+/**
+ * JPEG/AVIFにメタデータ(COMセグメント)を埋め込む
+ * シンプルに APP0/APP1 の直後に COM (Comment) セグメントを挿入
+ */
+function writeJpegMetadata(buffer, text) {
+  const view = new Uint8Array(buffer);
+  const textBytes = new TextEncoder().encode(text);
+
+  // COM marker: FF FE, Length: 2 + textBytes.length
+  const comSegment = new Uint8Array(2 + 2 + textBytes.length);
+  comSegment[0] = 0xFF;
+  comSegment[1] = 0xFE;
+  comSegment[2] = ((textBytes.length + 2) >> 8) & 0xFF;
+  comSegment[3] = (textBytes.length + 2) & 0xFF;
+  comSegment.set(textBytes, 4);
+
+  // JPEG/AVIF (Exif) の場合、SOI (FF D8) または ftyp の直後に挿入
+  let insertPos = 2;
+  if (view[0] !== 0xFF || view[1] !== 0xD8) {
+    // AVIF の場合は ftyp チャンクの次
+    const ftypIndex = findSequence(view, [0x66, 0x74, 0x79, 0x70]);
+    if (ftypIndex !== -1) {
+      const size = (view[ftypIndex - 4] << 24) | (view[ftypIndex - 3] << 16) | (view[ftypIndex - 2] << 8) | view[ftypIndex - 1];
+      insertPos = ftypIndex - 4 + size;
+    }
+  }
+
+  const out = new Uint8Array(view.length + comSegment.length);
+  out.set(view.slice(0, insertPos), 0);
+  out.set(comSegment, insertPos);
+  out.set(view.slice(insertPos), insertPos + comSegment.length);
+
+  return out;
 }

--- a/extension/settings_loader.js
+++ b/extension/settings_loader.js
@@ -10,7 +10,16 @@ window.DEFAULT_SETTINGS = {
     analyzeEverywhere: false,
     excludedSites: [],
     ignoredMetadataKeys: ['XML:com.adobe.xmp'],
-    ignoredSoftware: ['Adobe Photoshop', 'Adobe ImageReady', 'Celsys Studio Tool', 'GIMP', 'Paint.NET']
+    ignoredSoftware: ['Adobe Photoshop', 'Adobe ImageReady', 'Celsys Studio Tool', 'GIMP', 'Paint.NET'],
+    // ウィンドウ配置設定
+    modalWidth: 600,
+    modalHeight: 500,
+    modalX: 'center',
+    modalY: 'center',
+    // 編集・隠し機能設定
+    enableMetadataEditing: true,    // メタデータの編集を許可
+    advancedModeEnabled: false,
+    enableExperimentalWriting: false
 };
 
 // 現在の設定（グローバル変数として公開）

--- a/extension/settings_loader.js
+++ b/extension/settings_loader.js
@@ -17,7 +17,7 @@ window.DEFAULT_SETTINGS = {
     modalX: 'center',
     modalY: 'center',
     // 編集・隠し機能設定
-    enableMetadataEditing: true,    // メタデータの編集を許可
+    enableMetadataEditing: false,   // メタデータの編集を許可
     advancedModeEnabled: false,
     enableExperimentalWriting: false
 };

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -73,16 +73,6 @@
     transform: translateX(0);
     opacity: 1;
   }
-
-  from {
-    transform: translateX(100%);
-    opacity: 0;
-  }
-
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
 }
 
 
@@ -95,9 +85,7 @@
   height: 100%;
   background-color: rgba(0, 0, 0, 0.6);
   z-index: 2147483645;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  pointer-events: auto;
 }
 
 /* backdrop-filterはChromeなど対応ブラウザのみ適用 */
@@ -110,28 +98,33 @@
 
 /* モーダル本体 */
 .ai-meta-modal {
+  position: fixed;
   background-color: #1e1e1e;
   color: #e0e0e0;
   width: 600px;
-  max-width: 90vw;
-  max-height: 80vh;
+  max-width: 95vw;
+  max-height: 95vh;
   border-radius: 8px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.7);
   display: flex;
   flex-direction: column;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  border: 1px solid #333;
+  border: 1px solid #444;
+  z-index: 2147483647;
+  overflow: hidden;
+  user-select: none;
 }
 
 /* ヘッダー */
 .ai-meta-modal-header {
-  padding: 16px;
+  padding: 12px 16px;
   border-bottom: 1px solid #333;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  cursor: pointer;
-  /* ヘッダークリックで閉じるため */
+  cursor: move;
+  background-color: #2d2d2d;
+  flex-shrink: 0;
 }
 
 .ai-meta-modal-header h2 {
@@ -162,6 +155,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  user-select: text;
 }
 
 /* セクション */
@@ -169,7 +163,6 @@
   background-color: #252526;
   border-radius: 6px;
   border: 1px solid #333;
-  /* overflow: hidden; 削除: ツールチップ表示のため */
   display: flex;
   flex-direction: column;
 }
@@ -248,8 +241,23 @@
   white-space: pre-wrap;
   word-break: break-all;
   color: #d4d4d4;
-  max-height: 200px;
+  flex: 1;
   overflow-y: auto;
+  border: 1px solid transparent;
+  outline: none;
+  background: transparent;
+}
+
+.ai-meta-text-area[contenteditable="true"] {
+  background: #1a1a1b;
+  border-color: #444;
+  cursor: text;
+  user-select: text;
+}
+
+.ai-meta-text-area[contenteditable="true"]:focus {
+  border-color: #4a9eff;
+  box-shadow: inset 0 0 5px rgba(74, 158, 255, 0.2);
 }
 
 .ai-meta-text-area.empty {
@@ -264,6 +272,7 @@
   display: flex;
   justify-content: flex-end;
   background-color: #252526;
+  gap: 8px;
 }
 
 .ai-meta-copy-all-btn {
@@ -331,4 +340,79 @@
 .ai-meta-downloader-item:hover {
   transform: scale(1.02);
   z-index: 1;
+}
+
+/* リサイズハンドル */
+.ai-meta-resize-handle {
+  position: absolute;
+  z-index: 2147483647;
+  background: transparent;
+}
+
+.ai-meta-resize-handle:hover {
+  background: rgba(74, 158, 255, 0.1);
+}
+
+.ai-meta-resize-n {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 6px;
+  cursor: n-resize;
+}
+
+.ai-meta-resize-s {
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 6px;
+  cursor: s-resize;
+}
+
+.ai-meta-resize-e {
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  cursor: e-resize;
+}
+
+.ai-meta-resize-w {
+  top: 0;
+  left: 0;
+  width: 6px;
+  height: 100%;
+  cursor: w-resize;
+}
+
+.ai-meta-resize-ne {
+  top: 0;
+  right: 0;
+  width: 10px;
+  height: 10px;
+  cursor: ne-resize;
+}
+
+.ai-meta-resize-nw {
+  top: 0;
+  left: 0;
+  width: 10px;
+  height: 10px;
+  cursor: nw-resize;
+}
+
+.ai-meta-resize-se {
+  bottom: 0;
+  right: 0;
+  width: 10px;
+  height: 10px;
+  cursor: se-resize;
+}
+
+.ai-meta-resize-sw {
+  bottom: 0;
+  left: 0;
+  width: 10px;
+  height: 10px;
+  cursor: sw-resize;
 }

--- a/extension/ui.js
+++ b/extension/ui.js
@@ -308,10 +308,15 @@ function createModal(metadata, imageUrl = null) {
     const { positive, negative, other } = parseMetadataToTabs(metadata);
     const generatorName = detectGenerator(metadata);
 
-    // 既存のモーダルがあれば削除
+    // 既存のモーダルがあれば、クローズボタン経由で閉じる（Escapeリスナーの解除を含む）
     const existingOverlay = document.getElementById('ai-meta-modal-overlay');
     if (existingOverlay) {
-        existingOverlay.remove();
+        const existingCloseBtn = existingOverlay.querySelector('.ai-meta-close-btn');
+        if (existingCloseBtn) {
+            existingCloseBtn.click();
+        } else {
+            existingOverlay.remove();
+        }
     }
 
     // オーバーレイ

--- a/extension/ui.js
+++ b/extension/ui.js
@@ -304,17 +304,40 @@ function setupCopyButton(button, text) {
  * @param {Object} metadata - メタデータ
  * @returns {HTMLElement} - モーダルオーバーレイ要素
  */
-function createModal(metadata) {
+function createModal(metadata, imageUrl = null) {
     const { positive, negative, other } = parseMetadataToTabs(metadata);
     const generatorName = detectGenerator(metadata);
 
+    // 既存のモーダルがあれば削除
+    const existingOverlay = document.getElementById('ai-meta-modal-overlay');
+    if (existingOverlay) {
+        existingOverlay.remove();
+    }
+
     // オーバーレイ
     const overlay = document.createElement('div');
+    overlay.id = 'ai-meta-modal-overlay';
     overlay.className = 'ai-meta-modal-overlay';
 
-    // モーダルコンテナ
+    // モーダル本体
     const modal = document.createElement('div');
     modal.className = 'ai-meta-modal';
+
+    // 設定からサイズ・位置を適用
+    const width = settings.modalWidth || 600;
+    const height = settings.modalHeight || 500;
+    modal.style.width = width + 'px';
+    modal.style.height = height + 'px';
+
+    if (settings.modalX === 'center' || settings.modalY === 'center') {
+        modal.style.left = '50%';
+        modal.style.top = '50%';
+        modal.style.transform = 'translate(-50%, -50%)';
+    } else {
+        modal.style.left = (typeof settings.modalX === 'number' ? settings.modalX : 100) + 'px';
+        modal.style.top = (typeof settings.modalY === 'number' ? settings.modalY : 100) + 'px';
+        modal.style.transform = 'none';
+    }
 
     // ヘッダー
     const header = document.createElement('div');
@@ -327,6 +350,24 @@ function createModal(metadata) {
     closeBtn.className = 'ai-meta-close-btn';
     closeBtn.innerHTML = '&times;';
     closeBtn.title = 'Close';
+
+    // 閉じる機能の復元
+    const closeModal = () => {
+        overlay.remove();
+        document.removeEventListener('keydown', handleEsc);
+    };
+    const handleEsc = (e) => {
+        if (e.key === 'Escape') closeModal();
+    };
+
+    closeBtn.onclick = (e) => {
+        e.stopPropagation();
+        closeModal();
+    };
+    overlay.onclick = (e) => {
+        if (e.target === overlay) closeModal();
+    };
+    document.addEventListener('keydown', handleEsc);
 
     header.appendChild(title);
     header.appendChild(closeBtn);
@@ -351,15 +392,27 @@ function createModal(metadata) {
         copyBtn.className = 'ai-meta-copy-btn';
         copyBtn.textContent = 'Copy';
         copyBtn.setAttribute('data-tooltip', 'Copy to clipboard');
-        setupCopyButton(copyBtn, textContent);
+
+        // 編集内容を考慮したコピー
+        copyBtn.onclick = (e) => {
+            e.stopPropagation();
+            const area = section.querySelector('.ai-meta-text-area');
+            const textToCopy = area ? area.innerText : textContent;
+            copyToClipboard(textToCopy, copyBtn);
+        };
 
         sectionHeader.appendChild(label);
         sectionHeader.appendChild(copyBtn);
 
         const textArea = document.createElement('div');
         textArea.className = 'ai-meta-text-area';
-        textArea.textContent = textContent || 'None';
+        textArea.innerText = textContent || 'None';
         if (!textContent) textArea.classList.add('empty');
+
+        // 編集許可設定 (標準で有効、設定による制限も可能)
+        if (typeof settings.enableMetadataEditing === 'undefined' || settings.enableMetadataEditing) {
+            textArea.contentEditable = "true";
+        }
 
         section.appendChild(sectionHeader);
         section.appendChild(textArea);
@@ -484,20 +537,70 @@ function createModal(metadata) {
     const footer = document.createElement('div');
     footer.className = 'ai-meta-modal-footer';
 
+    // 実験的書き換え機能ボタン (隠し設定有効時のみ)
+    if (settings.advancedModeEnabled && settings.enableExperimentalWriting && imageUrl) {
+        const writeBtn = document.createElement('button');
+        writeBtn.className = 'ai-meta-copy-all-btn';
+        writeBtn.textContent = 'Update & Download';
+        writeBtn.style.backgroundColor = '#d32f2f'; // 警告色
+        writeBtn.setAttribute('data-tooltip', '埋め込みメタデータを更新してダウンロード(PNGのみ)');
+
+        writeBtn.onclick = async (e) => {
+            e.stopPropagation();
+            // 全セクションからデータを収集
+            const sections = content.querySelectorAll('.ai-meta-section');
+            const metadataPayload = {};
+            sections.forEach(sec => {
+                const label = sec.querySelector('.ai-meta-section-label').textContent;
+                const area = sec.querySelector('.ai-meta-text-area');
+                if (label === 'Positive Prompt') metadataPayload.positive = area.innerText;
+                else if (label === 'Negative Prompt') metadataPayload.negative = area.innerText;
+                else if (label === 'Other Settings') metadataPayload.other = area.innerText;
+            });
+
+            if (window.confirm('編集したメタデータで画像を再保存（ダウンロード）しますか？\n※元のファイルは変更されません。')) {
+                writeBtn.disabled = true;
+                writeBtn.textContent = 'Processing...';
+                try {
+                    const response = await browserAPI.runtime.sendMessage({
+                        action: 'writeMetadataAndDownload',
+                        imageUrl: imageUrl,
+                        metadata: metadataPayload
+                    });
+                    if (response && response.success) {
+                        showNotification('Metadata updated and download started!');
+                    } else {
+                        throw new Error(response.error || 'Failed to process image');
+                    }
+                } catch (err) {
+                    showNotification('Error: ' + err.message, 'error');
+                } finally {
+                    writeBtn.disabled = false;
+                    writeBtn.textContent = 'Update & Download';
+                }
+            }
+        };
+        footer.appendChild(writeBtn);
+    }
+
     const copyAllBtn = document.createElement('button');
     copyAllBtn.className = 'ai-meta-copy-all-btn';
     copyAllBtn.textContent = 'Copy All Data';
     copyAllBtn.setAttribute('data-tooltip', 'Copy all metadata (raw format)');
 
-    // 全データをraw形式で結合（JSON化しない）
-    let allDataRaw = '';
-    for (const [key, value] of Object.entries(metadata)) {
-        const valueStr = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);
-        allDataRaw += `${key}:\n${valueStr}\n\n`;
-    }
-    allDataRaw = allDataRaw.trim();
-
-    setupCopyButton(copyAllBtn, allDataRaw);
+    // 全データをraw形式で結合（編集内容を反映させるため、その場で取得）
+    copyAllBtn.onclick = (e) => {
+        e.stopPropagation();
+        let allDataRaw = '';
+        const sections = content.querySelectorAll('.ai-meta-section');
+        sections.forEach(sec => {
+            const label = sec.querySelector('.ai-meta-section-label').textContent;
+            const area = sec.querySelector('.ai-meta-text-area');
+            const text = area ? area.innerText : '';
+            allDataRaw += `${label}:\n${text}\n\n`;
+        });
+        copyToClipboard(allDataRaw.trim(), copyAllBtn);
+    };
 
     footer.appendChild(copyAllBtn);
 
@@ -507,41 +610,181 @@ function createModal(metadata) {
     modal.appendChild(footer);
     overlay.appendChild(modal);
 
-    // イベントハンドラ
-    const close = () => {
-        if (document.body) {
-            if (overlay.parentNode === document.body) {
-                document.body.removeChild(overlay);
-            }
-            document.body.style.overflow = ''; // スクロールロック解除
-        }
-    };
+    // スクロールロック (オプション)
+    // if (document.body) {
+    //     document.body.style.overflow = 'hidden';
+    // }
 
-    closeBtn.addEventListener('click', close);
-    overlay.addEventListener('click', (e) => {
-        if (e.target === overlay) close();
-    });
-    header.addEventListener('click', (e) => {
-        // ヘッダーをクリックしても閉じる（仕様書2.2.2項）
-        // ただし、閉じるボタン自体のクリックイベントと競合しないようにする
-        if (e.target !== closeBtn) close();
-    });
-
-    // Escキーで閉じる
-    const escHandler = (e) => {
-        if (e.key === 'Escape') {
-            close();
-            document.removeEventListener('keydown', escHandler);
-        }
-    };
-    document.addEventListener('keydown', escHandler);
-
-    // スクロールロック
-    if (document.body) {
-        document.body.style.overflow = 'hidden';
-    }
+    // ドラッグ & リサイズ初期化
+    initDragAndResize(modal, header);
 
     return overlay;
+}
+
+/**
+ * モーダルのドラッグとリサイズ機能を初期化
+ * @param {HTMLElement} modal - モーダル本体
+ * @param {HTMLElement} header - ドラッグハンドルとなるヘッダー
+ */
+function initDragAndResize(modal, header) {
+    let isDragging = false;
+    let isResizing = false;
+    let currentHandle = null;
+    let startX, startY, startWidth, startHeight, startLeft, startTop;
+
+    // リサイズハンドルの作成
+    const handles = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'];
+    handles.forEach(dir => {
+        const handle = document.createElement('div');
+        handle.className = `ai-meta-resize-handle ai-meta-resize-${dir}`;
+        handle.dataset.dir = dir;
+        modal.appendChild(handle);
+
+        handle.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            isResizing = true;
+            currentHandle = dir;
+            startX = e.clientX;
+            startY = e.clientY;
+            startWidth = modal.offsetWidth;
+            startHeight = modal.offsetHeight;
+            startLeft = modal.offsetLeft;
+            startTop = modal.offsetTop;
+
+            // 中央揃え解除
+            modal.style.transform = 'none';
+            modal.style.left = startLeft + 'px';
+            modal.style.top = startTop + 'px';
+
+            document.addEventListener('mousemove', handleMouseMove);
+            document.addEventListener('mouseup', handleMouseUp);
+        });
+    });
+
+    // ヘッダードラッグ
+    header.addEventListener('mousedown', (e) => {
+        if (e.target.tagName === 'BUTTON' || e.target.closest('button')) return;
+
+        isDragging = true;
+        startX = e.clientX;
+        startY = e.clientY;
+        startLeft = modal.offsetLeft;
+        startTop = modal.offsetTop;
+
+        // 中央揃え解除
+        modal.style.transform = 'none';
+        modal.style.left = startLeft + 'px';
+        modal.style.top = startTop + 'px';
+
+        document.addEventListener('mousemove', handleMouseMove);
+        document.addEventListener('mouseup', handleMouseUp);
+        e.preventDefault();
+    });
+
+    function handleMouseMove(e) {
+        if (isDragging) {
+            const dx = e.clientX - startX;
+            const dy = e.clientY - startY;
+            modal.style.left = (startLeft + dx) + 'px';
+            modal.style.top = (startTop + dy) + 'px';
+        } else if (isResizing) {
+            const dx = e.clientX - startX;
+            const dy = e.clientY - startY;
+            let newWidth = startWidth;
+            let newHeight = startHeight;
+            let newLeft = startLeft;
+            let newTop = startTop;
+
+            if (currentHandle.includes('e')) newWidth = startWidth + dx;
+            if (currentHandle.includes('w')) {
+                newWidth = startWidth - dx;
+                newLeft = startLeft + dx;
+            }
+            if (currentHandle.includes('s')) newHeight = startHeight + dy;
+            if (currentHandle.includes('n')) {
+                newHeight = startHeight - dy;
+                newTop = startTop + dy;
+            }
+
+            // 最小サイズ制約
+            if (newWidth > 300) {
+                modal.style.width = newWidth + 'px';
+                modal.style.left = newLeft + 'px';
+            }
+            if (newHeight > 200) {
+                modal.style.height = newHeight + 'px';
+                modal.style.top = newTop + 'px';
+            }
+        }
+    }
+
+    function handleMouseUp() {
+        if (isDragging || isResizing) {
+            // 設定を保存
+            saveWindowSettings(modal);
+        }
+        isDragging = false;
+        isResizing = false;
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+    }
+}
+
+/**
+ * ウィンドウの位置とサイズを設定に保存
+ * @param {HTMLElement} modal 
+ */
+function saveWindowSettings(modal) {
+    const settingsUpdate = {
+        modalWidth: modal.offsetWidth,
+        modalHeight: modal.offsetHeight,
+        modalX: modal.offsetLeft,
+        modalY: modal.offsetTop
+    };
+
+    // グローバルなsettingsオブジェクトも更新
+    Object.assign(settings, settingsUpdate);
+
+    // Chrome Storageに保存
+    if (typeof chrome !== 'undefined' && chrome.storage) {
+        chrome.storage.sync.set(settingsUpdate);
+    }
+}
+
+/**
+ * ヘルパークリップボードコピー
+ */
+async function copyToClipboard(text, button) {
+    try {
+        await navigator.clipboard.writeText(text);
+        const originalText = button.textContent;
+        button.textContent = 'Copied!';
+        button.classList.add('copied');
+        setTimeout(() => {
+            button.textContent = originalText;
+            button.classList.remove('copied');
+        }, 2000);
+    } catch (err) {
+        console.error('Failed to copy:', err);
+    }
+}
+
+/**
+ * 通知表示 (UI内)
+ */
+function showNotification(message, type = 'success') {
+    const notification = document.createElement('div');
+    notification.className = 'ai-meta-error-notification'; // スタイル流用
+    if (type === 'success') {
+        notification.style.backgroundColor = '#2ea043';
+    }
+    notification.textContent = message;
+    document.body.appendChild(notification);
+    setTimeout(() => {
+        notification.style.opacity = '0';
+        setTimeout(() => notification.remove(), 500);
+    }, 3000);
 }
 
 /**
@@ -562,7 +805,7 @@ function createDownloadButton() {
     // ここでは最低限だけ設定し、詳細はstyles.cssで
     btn.style.position = 'fixed';
     btn.style.bottom = '20px';
-    btn.style.right = '20px'; // エラー通知と被らないように調整が必要かも
+    btn.style.right = '20px';
     btn.style.zIndex = '2147483646'; // モーダルより下、バッジより上
 
     return btn;


### PR DESCRIPTION
- メタデータ表示ウィンドウがview metadataにかぶって見にくいのを修正
- メタデータ表示ウィンドウのドラッグ＆ドロップによる移動とリサイズ機能の実装
- メタデータ表示ウィンドウの位置・サイズ設定の保存・復元に対応
- メタデータ表示領域をテキストエディタ形式にした
- PNGの圧縮されたiTXtチャンクのデコードに対応

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the metadata viewer into a draggable, resizable modal with a text‑editor layout and optional editing (off by default). Added support for compressed PNG iTXt and an experimental “Update & Download” to rewrite and save embedded metadata.

- **New Features**
  - Text editor layout for Positive/Negative/Other; editing is toggleable under Options > Metadata Interaction; copy actions include edits.
  - Drag to move and resize with handles; size/position persist and can be set/reset under Options > Window Display.
  - Decode compressed PNG iTXt via `pako.js`; background now imports `pako.js`/`jszip.min.js`.
  - Experimental “Update & Download” to rewrite metadata and download a new file (supports PNG/WebP/JPEG; AVIF unsupported); hidden toggle in Options.

- **Bug Fixes**
  - Modal no longer overlaps the badge; z-index adjusted.
  - Fixed Escape key listener leak when replacing the modal.
  - Correct AVIF MIME type and safer filename parsing when the URL lacks an extension.
  - Parser safeguards: explicit error for AVIF writes; JPEG COM segment size limit enforced.

<sup>Written for commit 4bef89659ef07e0e825709c3ed096515240581c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

