### PR TITLE
fix: 堅牢化・バグ修正・UI改善

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -487,7 +487,7 @@ const DEFAULT_SETTINGS = {
     downloaderFolderMode: 'id_pageTitle', // 'id_pageTitle', 'pageTitle', 'domain', 'none'
     downloaderBaseFolder: 'AI_Meta_Viewer',
     downloaderUseRoot: false,
-    version: '1.5.3',
+    version: '1.5.4',
     // 共有設定の追加
     modalWidth: 800,
     modalHeight: 600,
@@ -1057,11 +1057,15 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                     const controller = new AbortController();
                     const timeoutId = setTimeout(() => controller.abort(), 10000);
 
-                    const response = await fetch(activeUrl, {
-                        headers: { 'Range': `bytes=0-${rangeSize}` },
-                        signal: controller.signal
-                    });
-                    clearTimeout(timeoutId);
+                    let response;
+                    try {
+                        response = await fetch(activeUrl, {
+                            headers: { 'Range': `bytes=0-${rangeSize}` },
+                            signal: controller.signal
+                        });
+                    } finally {
+                        clearTimeout(timeoutId);
+                    }
 
                     if (response.status === 206) {
                         isRangeRequest = true;
@@ -1120,11 +1124,15 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                     try {
                         const controller = new AbortController();
                         const timeoutId = setTimeout(() => controller.abort(), 10000);
-                        const tailResponse = await fetch(activeUrl, {
-                            headers: { 'Range': `bytes=${tailStart}-` },
-                            signal: controller.signal
-                        });
-                        clearTimeout(timeoutId);
+                        let tailResponse;
+                        try {
+                            tailResponse = await fetch(activeUrl, {
+                                headers: { 'Range': `bytes=${tailStart}-` },
+                                signal: controller.signal
+                            });
+                        } finally {
+                            clearTimeout(timeoutId);
+                        }
 
                         if (tailResponse.status === 206 || tailResponse.status === 200) {
                             const tailBuffer = await tailResponse.arrayBuffer();
@@ -1167,11 +1175,15 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                     try {
                         const controller = new AbortController();
                         const timeoutId = setTimeout(() => controller.abort(), 10000);
-                        const retryResponse = await fetch(activeUrl, {
-                            headers: { 'Range': `bytes=0-${retrySize}` },
-                            signal: controller.signal
-                        });
-                        clearTimeout(timeoutId);
+                        let retryResponse;
+                        try {
+                            retryResponse = await fetch(activeUrl, {
+                                headers: { 'Range': `bytes=0-${retrySize}` },
+                                signal: controller.signal
+                            });
+                        } finally {
+                            clearTimeout(timeoutId);
+                        }
 
                         if (retryResponse.status === 206) {
                             const newBuffer = await retryResponse.arrayBuffer();
@@ -1315,6 +1327,18 @@ function stopKeepAlive() {
 
 // Service Worker の起動時にkeep-aliveを開始
 startKeepAlive();
+
+// Service Worker 停止時にキャッシュインデックスを即時保存
+chrome.runtime.onSuspend.addListener(() => {
+    if (metadataCache.saveTimer) {
+        clearTimeout(metadataCache.saveTimer);
+        metadataCache.saveTimer = null;
+    }
+    // デバウンス待ちの保存を即時実行
+    metadataCache.storage.set({
+        [metadataCache.metaKey]: Array.from(metadataCache.index.entries())
+    });
+});
 
 // Service Worker の動作確認用
 loadSettings().then(() => {

--- a/extension/content.js
+++ b/extension/content.js
@@ -687,6 +687,15 @@ function observeGenericSafetensorsLinks() {
         }, 500);
     });
 
+    if (!document.body) {
+        debugLog('[AI Meta Viewer] document.body not found, waiting for DOMContentLoaded to start safetensors observer');
+        document.addEventListener('DOMContentLoaded', () => {
+            safetensorsObserver.observe(document.body, { childList: true, subtree: true });
+            debugLog('[AI Meta Viewer] Generic safetensors link observer started (deferred)');
+        }, { once: true });
+        return;
+    }
+
     safetensorsObserver.observe(document.body, {
         childList: true,
         subtree: true
@@ -876,37 +885,14 @@ function observeImages() {
     let globalUpdateTimeoutId = null;
 
     const observerCallback = (mutations) => {
-        if (timeoutId) {
-            clearTimeout(timeoutId);
-        }
-
-        // 頻繁な実行を防ぐため、デバウンスを入れる
-        // Pixivなどの高速スクロールに対応するため、100msから30msに短縮
-        timeoutId = setTimeout(() => {
-            processPendingNodes();
-        }, 30);
-
-        // フルスクリーンモーダルなどが開いた際にバッジの遮蔽状態を再計算する
-        // DOMの追加・削除があった場合に実行
-        // ここもデバウンスする
-        if (globalUpdateTimeoutId) {
-            clearTimeout(globalUpdateTimeoutId);
-        }
-        globalUpdateTimeoutId = setTimeout(() => {
-            if (typeof window.forceUpdateAllBadges === 'function') {
-                window.forceUpdateAllBadges();
-            }
-        }, 150); // processPendingNodesより少し後に実行
-
+        // まず pendingNodes にノードを追加してからデバウンスタイマーを設定する
+        // (setTimeout コールバックは非同期だが、意図を明確にするため先に追加)
         mutations.forEach((mutation) => {
             mutation.addedNodes.forEach((node) => {
                 if (node.nodeType === 1) { // ELEMENT_NODE
                     pendingNodes.add(node);
                 }
             });
-
-            // サイト個別の要素チェックは初期化時のみ実行（無限ループ防止）
-            // observeSiteSpecificElements(); // この行を削除
 
             mutation.removedNodes.forEach((node) => {
                 if (node.nodeType === 1) {
@@ -933,6 +919,28 @@ function observeImages() {
                 }
             }
         });
+
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
+
+        // 頻繁な実行を防ぐため、デバウンスを入れる
+        // Pixivなどの高速スクロールに対応するため、100msから30msに短縮
+        timeoutId = setTimeout(() => {
+            processPendingNodes();
+        }, 30);
+
+        // フルスクリーンモーダルなどが開いた際にバッジの遮蔽状態を再計算する
+        // DOMの追加・削除があった場合に実行
+        // ここもデバウンスする
+        if (globalUpdateTimeoutId) {
+            clearTimeout(globalUpdateTimeoutId);
+        }
+        globalUpdateTimeoutId = setTimeout(() => {
+            if (typeof window.forceUpdateAllBadges === 'function') {
+                window.forceUpdateAllBadges();
+            }
+        }, 150); // processPendingNodesより少し後に実行
     };
 
     const setupObserver = () => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "permissions": [
         "activeTab",
         "storage",

--- a/extension/options.html
+++ b/extension/options.html
@@ -517,7 +517,7 @@
                             <div class="setting-label-title" style="color: #333;">Enable metadata rewrite and download
                             </div>
                             <div class="setting-label-desc" style="color: #666;">Adds a button to download a new image
-                                with modified metadata embedded (PNG only)</div>
+                                with modified metadata embedded (PNG/WebP/JPEG, AVIF not supported)</div>
                         </div>
                     </label>
                 </div>

--- a/extension/options.js
+++ b/extension/options.js
@@ -21,7 +21,7 @@ const DEFAULT_SETTINGS = {
     enableMetadataEditing: false,
     enableExperimentalWriting: false,
     advancedModeEnabled: false,
-    version: '1.5.3'
+    version: '1.5.4'
 };
 
 // DOM Elements

--- a/extension/ui.js
+++ b/extension/ui.js
@@ -548,7 +548,7 @@ function createModal(metadata, imageUrl = null) {
         writeBtn.className = 'ai-meta-copy-all-btn';
         writeBtn.textContent = 'Update & Download';
         writeBtn.style.backgroundColor = '#d32f2f'; // 警告色
-        writeBtn.setAttribute('data-tooltip', '埋め込みメタデータを更新してダウンロード(PNGのみ)');
+        writeBtn.setAttribute('data-tooltip', '埋め込みメタデータを更新してダウンロード (PNG/WebP/JPEG対応、AVIFは非対応)');
 
         writeBtn.onclick = async (e) => {
             e.stopPropagation();
@@ -563,7 +563,15 @@ function createModal(metadata, imageUrl = null) {
                 else if (label === 'Other Settings') metadataPayload.other = area.innerText;
             });
 
-            if (window.confirm('編集したメタデータで画像を再保存（ダウンロード）しますか？\n※元のファイルは変更されません。')) {
+            // ステルスメタデータの警告
+            const hasStealthData = metadata && Object.keys(metadata).some(k =>
+                k.startsWith('Stealth PNG Info')
+            );
+            const stealthWarning = hasStealthData
+                ? '\n\n⚠ この画像にはアルファチャンネルに隠されたステルスメタデータが含まれています。\n保存後もステルスデータは残ります。'
+                : '';
+
+            if (window.confirm(`編集したメタデータで画像を再保存（ダウンロード）しますか？\n※元のファイルは変更されません。${stealthWarning}`)) {
                 writeBtn.disabled = true;
                 writeBtn.textContent = 'Processing...';
                 try {


### PR DESCRIPTION
[堅牢化]
- background.js: AbortControllerのclearTimeoutをtry...finallyで保護（Rangeリクエスト3箇所）
- background.js: chrome.runtime.onSuspendでService Worker停止時にキャッシュインデックスを即時保存
- content.js: observeGenericSafetensorsLinksでdocument.bodyがnullの場合にDOMContentLoadedまで遅延してobserveするよう修正

[コード品質]
- content.js: observerCallback内でpendingNodes.add()をsetTimeoutより先に実行するよう順序を整理

[UI改善]
- ui.js: Update & Downloadボタンのツールチップを「PNGのみ」から「PNG/WebP/JPEG対応、AVIFは非対応」に修正
- options.html: 同様にPNG onlyの説明を修正

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves robustness of image metadata fetching and DOM observers, fixes edge cases on startup/shutdown, and clarifies supported formats in the UI. Bumps extension version to 1.5.4.

- **Bug Fixes**
  - Ensured Range request timeouts always clear with try/finally around `AbortController` (3 spots in `background.js`).
  - Saved metadata cache index immediately on Service Worker suspend via `chrome.runtime.onSuspend` to prevent data loss.
  - Deferred generic safetensors link observer until `DOMContentLoaded` if `document.body` is not ready.
  - Added nodes to `pendingNodes` before debounce scheduling in the image observer to avoid missed processing.

- **UI Improvements**
  - Updated “Update & Download” tooltip and Options copy to “PNG/WebP/JPEG supported, AVIF not supported”.
  - Added a warning in the confirm dialog when stealth metadata is detected (alpha-channel embedded).

<sup>Written for commit fa4006dc85ac9b0da5084b547783debc5f16b648. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

