### PR TITLE
fix: onSuspendリスナーをasync化してストレージ保存の完了を保証

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -101,7 +101,7 @@ class PersistentLRUCache {
             } catch (e) {
                 console.error('Cache index save error:', e);
             }
-        }, 2000);
+        }, 500); // R1-c: デバウンス短縮（2000ms→500ms）でonSuspend前に保存される確率を向上
     }
 
     async get(url) {
@@ -1334,10 +1334,14 @@ chrome.runtime.onSuspend.addListener(async () => {
         clearTimeout(metadataCache.saveTimer);
         metadataCache.saveTimer = null;
     }
-    // デバウンス待ちの保存を即時実行（awaitでService Worker停止前に完了を保証）
-    await metadataCache.storage.set({
-        [metadataCache.metaKey]: Array.from(metadataCache.index.entries())
-    });
+    // デバウンス待ちの保存を即時実行（ベストエフォート: onSuspend内の非同期完了は仕様上保証されない）
+    try {
+        await metadataCache.storage.set({
+            [metadataCache.metaKey]: Array.from(metadataCache.index.entries())
+        });
+    } catch (e) {
+        console.error('[AI Meta Viewer] Failed to save cache index on suspend:', e);
+    }
 });
 
 // Service Worker の動作確認用

--- a/extension/background.js
+++ b/extension/background.js
@@ -1329,13 +1329,13 @@ function stopKeepAlive() {
 startKeepAlive();
 
 // Service Worker 停止時にキャッシュインデックスを即時保存
-chrome.runtime.onSuspend.addListener(() => {
+chrome.runtime.onSuspend.addListener(async () => {
     if (metadataCache.saveTimer) {
         clearTimeout(metadataCache.saveTimer);
         metadataCache.saveTimer = null;
     }
-    // デバウンス待ちの保存を即時実行
-    metadataCache.storage.set({
+    // デバウンス待ちの保存を即時実行（awaitでService Worker停止前に完了を保証）
+    await metadataCache.storage.set({
         [metadataCache.metaKey]: Array.from(metadataCache.index.entries())
     });
 });

--- a/extension/content.js
+++ b/extension/content.js
@@ -690,6 +690,7 @@ function observeGenericSafetensorsLinks() {
     if (!document.body) {
         debugLog('[AI Meta Viewer] document.body not found, waiting for DOMContentLoaded to start safetensors observer');
         document.addEventListener('DOMContentLoaded', () => {
+            if (!document.body) return; // R5: DOMContentLoaded後もbodyがない場合（リダイレクトページ等）は中断
             safetensorsObserver.observe(document.body, { childList: true, subtree: true });
             debugLog('[AI Meta Viewer] Generic safetensors link observer started (deferred)');
         }, { once: true });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the `chrome.runtime.onSuspend` listener async and await `metadataCache.storage.set` to best-effort save the cache index before the Service Worker stops. Add try/catch around the save, shorten the save debounce to 500ms, and re-check `document.body` after `DOMContentLoaded` to avoid observing on redirect pages.

<sup>Written for commit 8f793c04bc1bb3dbe981fc92861f95a0f57856a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

