### PR TITLE
Dev

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -487,7 +487,7 @@ const DEFAULT_SETTINGS = {
     downloaderFolderMode: 'id_pageTitle', // 'id_pageTitle', 'pageTitle', 'domain', 'none'
     downloaderBaseFolder: 'AI_Meta_Viewer',
     downloaderUseRoot: false,
-    version: '1.5.4',
+    version: '1.5.4.1',
     // 共有設定の追加
     modalWidth: 800,
     modalHeight: 600,
@@ -969,6 +969,12 @@ async function handleCivitaiZipDownload(images, context) {
  */
 async function handleFetchImageMetadata(imageUrl, base64Data = null) {
     debugLog('[AI Meta Viewer] Fetching metadata for:', imageUrl);
+
+    // blob: URL は Service Worker からアクセス不可のためスキップ
+    if (imageUrl.startsWith('blob:')) {
+        debugLog('[AI Meta Viewer] Skipping blob: URL (not accessible from Service Worker):', imageUrl);
+        return { success: true, metadata: {} };
+    }
 
     // 1. キャッシュチェック (Async)
     const cachedMetadata = await metadataCache.get(imageUrl);

--- a/extension/background.js
+++ b/extension/background.js
@@ -1130,107 +1130,115 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                         totalFileSize = buffer.byteLength; // totalFileSize を更新
                         isRangeRequest = true; // 以降の tail fetch ロジックを有効化
                         metadata = extractMetadata(buffer);
+
+                        // full fetch 成功後、完全なメタデータが取得できた場合は以降の再試行をスキップ
+                        if (!metadata.isIncomplete) {
+                            debugLog('[AI Meta Viewer] ✅ Full fetch successful, metadata complete.');
+                        }
                     } catch (fullFetchError) {
                         debugLog('[AI Meta Viewer] ⚠ Full fetch fallback failed:', fullFetchError.message);
                     }
                 }
 
-                // ComfyUI (PNGの末尾にメタデータがあるパターン)
-                // W2: totalFileSize が異常に小さい場合（W1の問題発生時）は tail fetch をスキップ
-                if (metadata.requiresTailFetch && totalFileSize > 65535 && isRangeRequest) {
-                    const tailSize = 131072; // 末尾 128KB 取得
-                    let tailStart = totalFileSize - tailSize;
-                    if (tailStart < 65536) tailStart = 65536; // 既取得分と被らないように
+                // full fetch 後に完全なメタデータが取得できた場合は以降をスキップ
+                if (metadata.isIncomplete) {
+                    // ComfyUI (PNGの末尾にメタデータがあるパターン)
+                    // W2: totalFileSize が異常に小さい場合（W1の問題発生時）は tail fetch をスキップ
+                    if (metadata.requiresTailFetch && totalFileSize > 65535 && isRangeRequest) {
+                        const tailSize = 131072; // 末尾 128KB 取得
+                        let tailStart = totalFileSize - tailSize;
+                        if (tailStart < 65536) tailStart = 65536; // 既取得分と被らないように
 
-                    debugLog(`[AI Meta Viewer] ⚠ ComfyUI signature detected. Fetching tail for metadata: bytes=${tailStart}-`);
-                    try {
-                        const controller = new AbortController();
-                        const timeoutId = setTimeout(() => controller.abort(), 10000);
-                        let tailResponse;
+                        debugLog(`[AI Meta Viewer] ⚠ ComfyUI signature detected. Fetching tail for metadata: bytes=${tailStart}-`);
                         try {
-                            tailResponse = await fetch(activeUrl, {
-                                headers: { 'Range': `bytes=${tailStart}-` },
-                                signal: controller.signal
-                            });
-                        } finally {
-                            clearTimeout(timeoutId);
-                        }
-
-                        if (tailResponse.status === 206 || tailResponse.status === 200) {
-                            const tailBuffer = await tailResponse.arrayBuffer();
-
-                            // 画像形式に応じて適切な末尾解析器を呼び出す
-                            const format = detectImageFormat(buffer);
-                            let tailMetadata = {};
-
-                            if (format === 'png') {
-                                tailMetadata = extractPngTailMetadata(tailBuffer);
-                            } else if (format === 'webp') {
-                                tailMetadata = extractWebpTailMetadata(tailBuffer);
+                            const controller = new AbortController();
+                            const timeoutId = setTimeout(() => controller.abort(), 10000);
+                            let tailResponse;
+                            try {
+                                tailResponse = await fetch(activeUrl, {
+                                    headers: { 'Range': `bytes=${tailStart}-` },
+                                    signal: controller.signal
+                                });
+                            } finally {
+                                clearTimeout(timeoutId);
                             }
 
-                            const foundKeys = Object.keys(tailMetadata);
-                            if (foundKeys.length > 0) {
-                                debugLog(`[AI Meta Viewer] ✅ Tail meta found: ${foundKeys.join(', ')}`);
-                                Object.assign(metadata, tailMetadata);
+                            if (tailResponse.status === 206 || tailResponse.status === 200) {
+                                const tailBuffer = await tailResponse.arrayBuffer();
+
+                                // 画像形式に応じて適切な末尾解析器を呼び出す
+                                const format = detectImageFormat(buffer);
+                                let tailMetadata = {};
+
+                                if (format === 'png') {
+                                    tailMetadata = extractPngTailMetadata(tailBuffer);
+                                } else if (format === 'webp') {
+                                    tailMetadata = extractWebpTailMetadata(tailBuffer);
+                                }
+
+                                const foundKeys = Object.keys(tailMetadata);
+                                if (foundKeys.length > 0) {
+                                    debugLog(`[AI Meta Viewer] ✅ Tail meta found: ${foundKeys.join(', ')}`);
+                                    Object.assign(metadata, tailMetadata);
+                                } else {
+                                    debugLog('[AI Meta Viewer] ⚠ Tail Range fetched but no metadata found in tail.');
+                                }
+
+                                // フラグクリア
+                                delete metadata.isIncomplete;
+                                delete metadata.requiresTailFetch;
                             } else {
-                                debugLog('[AI Meta Viewer] ⚠ Tail Range fetched but no metadata found in tail.');
+                                debugLog(`[AI Meta Viewer] ⚠ Tail Range failed (Status: ${tailResponse.status}), giving up.`);
+                            }
+                            isRangeRequest = false; // これ以上のフェッチを防ぐ
+                        } catch (tailError) {
+                            debugLog('[AI Meta Viewer] ⚠ Tail Range threw error:', tailError.message);
+                            isRangeRequest = false;
+                        }
+                    }
+                    // 通常の再試行 (Safetensorsなど、前方をもっと読む)
+                    else {
+                        const retrySize = metadata.suggestedSize || 131072;
+                        debugLog(`[AI Meta Viewer] ⚠ Metadata is incomplete. Retrying with larger range: 0-${retrySize}`);
+
+                        try {
+                            const controller = new AbortController();
+                            const timeoutId = setTimeout(() => controller.abort(), 10000);
+                            let retryResponse;
+                            try {
+                                retryResponse = await fetch(activeUrl, {
+                                    headers: { 'Range': `bytes=0-${retrySize}` },
+                                    signal: controller.signal
+                                });
+                            } finally {
+                                clearTimeout(timeoutId);
                             }
 
-                            // フラグクリア
-                            delete metadata.isIncomplete;
-                            delete metadata.requiresTailFetch;
-                        } else {
-                            debugLog(`[AI Meta Viewer] ⚠ Tail Range failed (Status: ${tailResponse.status}), giving up.`);
-                        }
-                        isRangeRequest = false; // これ以上のフェッチを防ぐ
-                    } catch (tailError) {
-                        debugLog('[AI Meta Viewer] ⚠ Tail Range threw error:', tailError.message);
-                        isRangeRequest = false;
-                    }
-                }
-                // 通常の再試行 (Safetensorsなど、前方をもっと読む)
-                else {
-                    const retrySize = metadata.suggestedSize || 131072;
-                    debugLog(`[AI Meta Viewer] ⚠ Metadata is incomplete. Retrying with larger range: 0-${retrySize}`);
-
-                    try {
-                        const controller = new AbortController();
-                        const timeoutId = setTimeout(() => controller.abort(), 10000);
-                        let retryResponse;
-                        try {
-                            retryResponse = await fetch(activeUrl, {
-                                headers: { 'Range': `bytes=0-${retrySize}` },
-                                signal: controller.signal
-                            });
-                        } finally {
-                            clearTimeout(timeoutId);
-                        }
-
-                        if (retryResponse.status === 206) {
-                            const newBuffer = await retryResponse.arrayBuffer();
-                            const nextMetadata = extractMetadata(newBuffer);
-                            if (nextMetadata.isIncomplete) {
-                                debugLog('[AI Meta Viewer] ⚠ Still incomplete. Falling back to safe full fetch.');
+                            if (retryResponse.status === 206) {
+                                const newBuffer = await retryResponse.arrayBuffer();
+                                const nextMetadata = extractMetadata(newBuffer);
+                                if (nextMetadata.isIncomplete) {
+                                    debugLog('[AI Meta Viewer] ⚠ Still incomplete. Falling back to safe full fetch.');
+                                    const fullBuffer = await safeFetchFull(activeUrl);
+                                    metadata = extractMetadata(fullBuffer);
+                                } else {
+                                    metadata = nextMetadata;
+                                    buffer = newBuffer;
+                                }
+                            } else {
+                                debugLog('[AI Meta Viewer] ⚠ Retry Range failed, falling back to safe full fetch.');
                                 const fullBuffer = await safeFetchFull(activeUrl);
                                 metadata = extractMetadata(fullBuffer);
-                            } else {
-                                metadata = nextMetadata;
-                                buffer = newBuffer;
                             }
-                        } else {
-                            debugLog('[AI Meta Viewer] ⚠ Retry Range failed, falling back to safe full fetch.');
+                            isRangeRequest = false;
+                        } catch (retryError) {
+                            debugLog('[AI Meta Viewer] ⚠ Range retry failed, final attempt with safe full fetch:', retryError.message);
                             const fullBuffer = await safeFetchFull(activeUrl);
                             metadata = extractMetadata(fullBuffer);
+                            isRangeRequest = false;
                         }
-                        isRangeRequest = false;
-                    } catch (retryError) {
-                        debugLog('[AI Meta Viewer] ⚠ Range retry failed, final attempt with safe full fetch:', retryError.message);
-                        const fullBuffer = await safeFetchFull(activeUrl);
-                        metadata = extractMetadata(fullBuffer);
-                        isRangeRequest = false;
                     }
-                }
+                } // if (metadata.isIncomplete) の終わり
             }
         } catch (e) {
             debugLog('[AI Meta Viewer] Parse failed, trying safe full fetch fallback:', e.message);

--- a/extension/background.js
+++ b/extension/background.js
@@ -1127,6 +1127,8 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                     try {
                         const fullBuffer = await safeFetchFull(activeUrl);
                         buffer = fullBuffer;
+                        totalFileSize = buffer.byteLength; // totalFileSize を更新
+                        isRangeRequest = true; // 以降の tail fetch ロジックを有効化
                         metadata = extractMetadata(buffer);
                     } catch (fullFetchError) {
                         debugLog('[AI Meta Viewer] ⚠ Full fetch fallback failed:', fullFetchError.message);
@@ -1135,7 +1137,7 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
 
                 // ComfyUI (PNGの末尾にメタデータがあるパターン)
                 // W2: totalFileSize が異常に小さい場合（W1の問題発生時）は tail fetch をスキップ
-                else if (metadata.requiresTailFetch && totalFileSize > 65535) {
+                if (metadata.requiresTailFetch && totalFileSize > 65535 && isRangeRequest) {
                     const tailSize = 131072; // 末尾 128KB 取得
                     let tailStart = totalFileSize - tailSize;
                     if (tailStart < 65536) tailStart = 65536; // 既取得分と被らないように

--- a/extension/background.js
+++ b/extension/background.js
@@ -1128,19 +1128,23 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                         const fullBuffer = await safeFetchFull(activeUrl);
                         buffer = fullBuffer;
                         totalFileSize = buffer.byteLength; // totalFileSize を更新
-                        isRangeRequest = true; // 以降の tail fetch ロジックを有効化
                         metadata = extractMetadata(buffer);
 
                         // full fetch 成功後、完全なメタデータが取得できた場合は以降の再試行をスキップ
                         if (!metadata.isIncomplete) {
                             debugLog('[AI Meta Viewer] ✅ Full fetch successful, metadata complete.');
+                            // isRangeRequest は false のまま（Stealth PNG チェックでの重複ダウンロードを防ぐ）
+                        } else {
+                            // まだ incomplete の場合のみ、tail fetch を有効化
+                            isRangeRequest = true;
                         }
                     } catch (fullFetchError) {
                         debugLog('[AI Meta Viewer] ⚠ Full fetch fallback failed:', fullFetchError.message);
                     }
                 }
 
-                // full fetch 後に完全なメタデータが取得できた場合は以降をスキップ
+                // full fetch 後も metadata.isIncomplete を再チェック
+                // 完全なメタデータが取得できた場合は以降の再試行をスキップ
                 if (metadata.isIncomplete) {
                     // ComfyUI (PNGの末尾にメタデータがあるパターン)
                     // W2: totalFileSize が異常に小さい場合（W1の問題発生時）は tail fetch をスキップ
@@ -1220,7 +1224,8 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                                 if (nextMetadata.isIncomplete) {
                                     debugLog('[AI Meta Viewer] ⚠ Still incomplete. Falling back to safe full fetch.');
                                     const fullBuffer = await safeFetchFull(activeUrl);
-                                    buffer = fullBuffer; // buffer を更新
+                                    buffer = fullBuffer;
+                                    totalFileSize = buffer.byteLength; // totalFileSize を更新
                                     metadata = extractMetadata(fullBuffer);
                                 } else {
                                     metadata = nextMetadata;
@@ -1229,14 +1234,16 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                             } else {
                                 debugLog('[AI Meta Viewer] ⚠ Retry Range failed, falling back to safe full fetch.');
                                 const fullBuffer = await safeFetchFull(activeUrl);
-                                buffer = fullBuffer; // buffer を更新
+                                buffer = fullBuffer;
+                                totalFileSize = buffer.byteLength; // totalFileSize を更新
                                 metadata = extractMetadata(fullBuffer);
                             }
                             isRangeRequest = false;
                         } catch (retryError) {
                             debugLog('[AI Meta Viewer] ⚠ Range retry failed, final attempt with safe full fetch:', retryError.message);
                             const fullBuffer = await safeFetchFull(activeUrl);
-                            buffer = fullBuffer; // buffer を更新
+                            buffer = fullBuffer;
+                            totalFileSize = buffer.byteLength; // totalFileSize を更新
                             metadata = extractMetadata(fullBuffer);
                             isRangeRequest = false;
                         }

--- a/extension/background.js
+++ b/extension/background.js
@@ -1220,6 +1220,7 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                                 if (nextMetadata.isIncomplete) {
                                     debugLog('[AI Meta Viewer] ⚠ Still incomplete. Falling back to safe full fetch.');
                                     const fullBuffer = await safeFetchFull(activeUrl);
+                                    buffer = fullBuffer; // buffer を更新
                                     metadata = extractMetadata(fullBuffer);
                                 } else {
                                     metadata = nextMetadata;
@@ -1228,12 +1229,14 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
                             } else {
                                 debugLog('[AI Meta Viewer] ⚠ Retry Range failed, falling back to safe full fetch.');
                                 const fullBuffer = await safeFetchFull(activeUrl);
+                                buffer = fullBuffer; // buffer を更新
                                 metadata = extractMetadata(fullBuffer);
                             }
                             isRangeRequest = false;
                         } catch (retryError) {
                             debugLog('[AI Meta Viewer] ⚠ Range retry failed, final attempt with safe full fetch:', retryError.message);
                             const fullBuffer = await safeFetchFull(activeUrl);
+                            buffer = fullBuffer; // buffer を更新
                             metadata = extractMetadata(fullBuffer);
                             isRangeRequest = false;
                         }

--- a/extension/background.js
+++ b/extension/background.js
@@ -487,7 +487,7 @@ const DEFAULT_SETTINGS = {
     downloaderFolderMode: 'id_pageTitle', // 'id_pageTitle', 'pageTitle', 'domain', 'none'
     downloaderBaseFolder: 'AI_Meta_Viewer',
     downloaderUseRoot: false,
-    version: '1.5.4.1',
+    version: '1.5.4.2',
     // 共有設定の追加
     modalWidth: 800,
     modalHeight: 600,
@@ -1118,10 +1118,24 @@ async function handleFetchImageMetadata(imageUrl, base64Data = null) {
             metadata = extractMetadata(buffer);
 
             // メタデータ不足時の再試行ロジック
-            if (metadata.isIncomplete && isRangeRequest) {
+            if (metadata.isIncomplete) {
+
+                if (!isRangeRequest) {
+                    // file:// URL 等で Range が暗黙的に効いてバッファが切り詰められたケース
+                    // safeFetchFull で全ファイルを取得して再解析
+                    debugLog('[AI Meta Viewer] ⚠ Metadata incomplete but not a Range request. Attempting full fetch fallback.');
+                    try {
+                        const fullBuffer = await safeFetchFull(activeUrl);
+                        buffer = fullBuffer;
+                        metadata = extractMetadata(buffer);
+                    } catch (fullFetchError) {
+                        debugLog('[AI Meta Viewer] ⚠ Full fetch fallback failed:', fullFetchError.message);
+                    }
+                }
 
                 // ComfyUI (PNGの末尾にメタデータがあるパターン)
-                if (metadata.requiresTailFetch && totalFileSize > 65535) {
+                // W2: totalFileSize が異常に小さい場合（W1の問題発生時）は tail fetch をスキップ
+                else if (metadata.requiresTailFetch && totalFileSize > 65535) {
                     const tailSize = 131072; // 末尾 128KB 取得
                     let tailStart = totalFileSize - tailSize;
                     if (tailStart < 65536) tailStart = 65536; // 既取得分と被らないように

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "1.5.4",
+    "version": "1.5.4.1",
     "permissions": [
         "activeTab",
         "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "1.5.4.1",
+    "version": "1.5.4.2",
     "permissions": [
         "activeTab",
         "storage",

--- a/extension/options.js
+++ b/extension/options.js
@@ -21,7 +21,7 @@ const DEFAULT_SETTINGS = {
     enableMetadataEditing: false,
     enableExperimentalWriting: false,
     advancedModeEnabled: false,
-    version: '1.5.4'
+    version: '1.5.4.1'
 };
 
 // DOM Elements

--- a/extension/options.js
+++ b/extension/options.js
@@ -21,7 +21,7 @@ const DEFAULT_SETTINGS = {
     enableMetadataEditing: false,
     enableExperimentalWriting: false,
     advancedModeEnabled: false,
-    version: '1.5.4.1'
+    version: '1.5.4.2'
 };
 
 // DOM Elements

--- a/extension/parser.js
+++ b/extension/parser.js
@@ -332,7 +332,11 @@ function extractWebpMetadata(buffer) {
 
   // RIFFサイズ (Little Endian)
   const riffSize = view[4] | (view[5] << 8) | (view[6] << 16) | (view[7] << 24);
-  const totalSize = riffSize + 8;
+  const declaredSize = riffSize + 8;
+  // W1: 壊れたRIFFサイズフィールドへの対処
+  // declaredSize が実バッファより小さい場合、RIFFサイズが壊れている可能性がある
+  // Math.max で実バッファサイズを使用し、チャンク走査を末尾まで続行させる
+  const totalSize = Math.max(declaredSize, view.length);
 
   // RIFFヘッダーをスキップ (12バイト: "RIFF" + size + "WEBP")
   let offset = 12;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incomplete WebP metadata reads and range‑truncated fetches, and prevents duplicate downloads after full‑fetch fallback. Skips `blob:` URLs and bumps version to 1.5.4.2.

- **Bug Fixes**
  - Skip `blob:` URLs to avoid Service Worker access errors.
  - If metadata is incomplete without Range, do a full fetch; on success keep `isRangeRequest` false to avoid Stealth PNG double fetches, update `buffer` and `totalFileSize`, and only tail‑fetch when size is valid.
  - WebP parser reads trailing EXIF/XMP even with a corrupted RIFF size by scanning up to the actual buffer length.

<sup>Written for commit 85825d33868ccc82026cd46ad46bc1e674ebc69f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

